### PR TITLE
docs: align readme and setup guides with current scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devhub
 
-Kubernetes DevOps platform for local development and UpCloud production. Two layers: **OpenTofu** provisions cloud infrastructure, **Helm/K8s scripts** deploy platform services on top.
+Kubernetes DevOps platform for local development and cloud environments. Two layers: **OpenTofu** provisions cloud infrastructure, **Helm/K8s scripts** deploy platform services on top.
 
 ## Platform Services
 
@@ -19,26 +19,31 @@ Kubernetes DevOps platform for local development and UpCloud production. Two lay
 
 | Environment | Infrastructure | Data Services | Domain |
 |-------------|---------------|---------------|--------|
-| `local` | Rancher Desktop (WSL2) | StatefulSets (PG, Valkey, MinIO) | `*.localhost` |
-| `upcloud-dev` | UpCloud Managed K8s | UpCloud Managed (PG, Valkey, S3) | configurable |
-| `upcloud-prod` | UpCloud Managed K8s | UpCloud Managed (PG, Valkey, S3) | configurable |
+| `local` | Local Kubernetes (Rancher Desktop or similar) | StatefulSets (PG, Valkey, MinIO) | `*.localhost` |
+| `upcloud-dev`, `upcloud-prod` | UpCloud Managed K8s | Managed (PG, Valkey, S3) | configurable |
+| `azure-dev`, `azure-prod` | AKS | Managed (PostgreSQL, Redis, Blob) | configurable |
+| `gcp-dev`, `gcp-prod` | GKE | Managed (PostgreSQL, Redis, GCS) | configurable |
+| `aws-dev`, `aws-prod` | EKS | Managed (PostgreSQL, Redis, S3) | configurable |
 
 ## Repository Structure
 
 ```
 devhub/
-├── tofu/upcloud/                    # Infrastructure as Code (OpenTofu)
-│   ├── modules/cluster/             #   Shared module: K8s cluster + managed data services
-│   ├── dev/                         #   Dev root module (smaller plans, no termination protection)
-│   └── prod/                        #   Prod root module (larger plans, termination protection)
+├── tofu/                            # Infrastructure as Code (OpenTofu)
+│   ├── upcloud/                     #   UpCloud modules + env roots
+│   ├── azure/                       #   Azure modules + env roots
+│   ├── gcp/                         #   GCP modules + env roots
+│   └── aws/                         #   AWS modules + env roots
 │
 ├── k8s/                             # Kubernetes platform deployment
 │   ├── base/devops/                 #   Base Helm values for each service
 │   ├── overlays/
 │   │   ├── local/                   #   Local: config.yaml + Helm overrides + data-services
-│   │   ├── upcloud/devops/          #   Shared UpCloud Helm value overrides
-│   │   ├── upcloud-dev/             #   UpCloud dev: config.yaml + symlink to upcloud/devops
-│   │   └── upcloud-prod/            #   UpCloud prod: config.yaml + symlink to upcloud/devops
+│   │   ├── upcloud/, azure/, gcp/, aws/  #   Shared cloud Helm value overrides
+│   │   ├── upcloud-dev/, upcloud-prod/   #   UpCloud env overlays
+│   │   ├── azure-dev/, azure-prod/       #   Azure env overlays
+│   │   ├── gcp-dev/, gcp-prod/           #   GCP env overlays
+│   │   └── aws-dev/, aws-prod/           #   AWS env overlays
 │   ├── argocd/                      #   ArgoCD app-of-apps manifests (GitOps)
 │   ├── scripts/                     #   Deployment and setup scripts
 │   └── docs/                        #   Detailed setup guides
@@ -80,15 +85,14 @@ export KUBECONFIG=upcloud-dev/kubeconfig
 
 ### Infrastructure Layer (OpenTofu)
 
-The `tofu/upcloud/` directory provisions UpCloud resources:
+The `tofu/` directory contains provider-specific modules and environment roots for UpCloud, Azure, GCP, and AWS. Managed deployments provision:
 
-- **Networking**: Private SDN network, router, NAT gateway
-- **Kubernetes**: Managed K8s cluster with private worker nodes
-- **PostgreSQL**: Managed database with `keycloak` and `gitlabhq_production` databases
-- **Valkey**: Managed Redis-compatible cache for GitLab
-- **Object Storage**: S3-compatible storage with GitLab buckets (artifacts, uploads, packages, LFS, registry, backups)
+- **Kubernetes cluster** (provider-managed)
+- **PostgreSQL** for Keycloak and GitLab
+- **Redis/Valkey** for GitLab caching/session workloads
+- **Object storage** for GitLab artifacts, packages, registry, and backups
 
-All managed services are attached to the private network with public access disabled. Dev and prod environments use separate tofu state files and can have different plans/sizing.
+Dev and prod environments use separate state and configurable sizing.
 
 ### Platform Layer (K8s Scripts)
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Platform
 
-Deploys the DevOps platform services onto Kubernetes clusters. Supports local development (Rancher Desktop) and UpCloud managed clusters.
+Deploys the DevOps platform services onto Kubernetes clusters. Supports local development and managed cloud clusters (UpCloud, Azure, GCP, AWS).
 
 **Applications are managed via ArgoCD GitOps** — see [argocd/README.md](argocd/README.md).
 
@@ -35,6 +35,10 @@ k8s/
 │   └── upcloud-prod/                # UpCloud prod environment
 │       ├── config.yaml
 │       └── devops -> ../upcloud/devops
+│   ├── azure/, azure-dev/, azure-prod/
+│   │                                 # Azure shared + env-specific overlays
+│   ├── gcp/, gcp-dev/, gcp-prod/     # GCP shared + env-specific overlays
+│   └── aws/, aws-dev/, aws-prod/     # AWS shared + env-specific overlays
 ├── scripts/
 │   ├── lib/common.sh                # Shared library (logging, config, templating)
 │   ├── deploy.sh                    # Main deployment script
@@ -95,13 +99,16 @@ export KUBECONFIG=upcloud-dev/kubeconfig
 ## Deploy Script Usage
 
 ```bash
-./deploy.sh --env local|upcloud-dev|upcloud-prod [component] [action]
+./deploy.sh --env <environment> [component] [action]
 ```
+
+Supported environments:
+`local`, `upcloud-dev`, `upcloud-prod`, `azure-dev`, `azure-prod`, `gcp-dev`, `gcp-prod`, `aws-dev`, `aws-prod`
 
 **Components:**
 - `all` / `devops` — Deploy entire platform (default)
 - `keycloak`, `vault`, `monitoring`, `gitlab`, `argocd` — Individual services
-- `data-services` — Data services only (local: StatefulSets, upcloud: managed config)
+- `data-services` — Data services only (local: StatefulSets, managed envs: external service wiring)
 - `bootstrap` — Deploy ArgoCD app-of-apps
 - `ingress` — Apply ingress rules only
 

--- a/k8s/docs/KEYCLOAK_SSO.md
+++ b/k8s/docs/KEYCLOAK_SSO.md
@@ -96,12 +96,12 @@ The Keycloak configuration is fully automated and integrated into the deployment
 
 ```bash
 # Run the complete setup (includes Keycloak configuration)
-./scripts/local/setup-all.sh
+cd k8s/scripts
+./setup-all.sh --env local
 
 # Or run Keycloak configuration separately
-cd k8s/scripts/local
-export DOMAIN=localhost
-./setup-keycloak.sh all
+cd k8s/scripts
+./setup-keycloak.sh --env local all
 ```
 
 ### What the Script Does
@@ -178,9 +178,9 @@ All services use these Keycloak endpoints:
 2. Check Keycloak logs: `kubectl logs -n keycloak keycloak-keycloakx-0`
 3. Try running individual steps:
    ```bash
-   ./setup-keycloak.sh realm    # Create realm only
-   ./setup-keycloak.sh clients  # Configure clients only
-   ./setup-keycloak.sh user     # Create admin user only
+   ./setup-keycloak.sh --env local realm    # Create realm only
+   ./setup-keycloak.sh --env local clients  # Configure clients only
+   ./setup-keycloak.sh --env local user     # Create admin user only
    ```
 
 ## Security Considerations

--- a/k8s/docs/LOCAL_SETUP.md
+++ b/k8s/docs/LOCAL_SETUP.md
@@ -1,267 +1,133 @@
-# Local Development Quick Start Guide
+# Local Development Setup (Windows + WSL)
 
-This guide walks you through setting up trusted HTTPS for local Kubernetes development on Windows with WSL and Rancher Desktop.
+This guide sets up trusted HTTPS for local Kubernetes development on Windows with WSL2.
 
 ## Prerequisites
 
-- **Windows 11** or Windows 10
-- **WSL 2** with Ubuntu or similar distribution
-- **Rancher Desktop** installed and running with:
-  - Container Runtime: dockerd (moby)
-  - Kubernetes enabled
-- **kubectl** installed in WSL
-- **helm** installed in WSL
-- **openssl** installed in WSL (usually pre-installed)
+- Windows 10/11
+- WSL2 (Ubuntu or similar)
+- Rancher Desktop (or another local Kubernetes distribution)
+- `kubectl`, `helm`, `openssl`, `jq`, `envsubst` in WSL
 
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     Windows Host                             │
-│  ┌─────────────┐                                            │
-│  │   Browser   │ ◄─── HTTPS (trusted)                       │
-│  └──────┬──────┘                                            │
-│         │                                                    │
-│         ▼                                                    │
-│   hosts file: app.localhost → 127.0.0.1                     │
-│                                                              │
-│  ┌─────────────────────────────────────────────────────────┐│
-│  │                      WSL 2                               ││
-│  │  ┌───────────────────────────────────────────────────┐  ││
-│  │  │              Rancher Desktop K8s                   │  ││
-│  │  │                                                    │  ││
-│  │  │  ┌──────────────┐  ┌──────────────┐              │  ││
-│  │  │  │nginx-ingress │  │   Services   │              │  ││
-│  │  │  │ (port 443)   │──│  (devhub ns)  │              │  ││
-│  │  │  │  + TLS cert  │  │              │              │  ││
-│  │  │  └──────────────┘  └──────────────┘              │  ││
-│  │  │                                                    │  ││
-│  │  │  local-tls-secret (generated cert)                │  ││
-│  │  │  local-ca-certificates (CA for service trust)     │  ││
-│  │  └───────────────────────────────────────────────────┘  ││
-│  └─────────────────────────────────────────────────────────┘│
-│                                                              │
-│  Windows Certificate Store: Local Development CA (trusted)  │
-└─────────────────────────────────────────────────────────────┘
-```
-
-## Step-by-Step Setup
-
-### Quick Start (Fully Automated)
-
-For a completely automated setup with **zero manual intervention**, run:
+## Quick Start (Automated)
 
 ```bash
-cd k8s/scripts/local
-./setup-all.sh
+cd k8s/scripts
+./setup-all.sh --env local
 ```
 
-This single command will:
-1. Generate CA and TLS certificates
-2. Install nginx-ingress controller
-3. Deploy all DevOps components (Keycloak, Vault, GitLab, ArgoCD, Monitoring)
-4. Initialize and unseal Vault
-5. Configure Keycloak realm and OIDC clients
-6. Wait for GitLab to be ready
-7. Bootstrap ArgoCD app-of-apps
+This command:
+1. Generates local CA and wildcard localhost certs
+2. Installs ingress-nginx and cluster prerequisites
+3. Deploys platform services
+4. Initializes and configures Vault
+5. Configures Keycloak realm and OIDC clients
+6. Bootstraps ArgoCD app-of-apps
 
-Estimated time: 20-40 minutes (GitLab takes the longest)
+## Manual Setup (Step by Step)
 
-### Manual Step-by-Step (Alternative)
-
-If you prefer to run each step manually:
-
-#### Step 1: Generate Certificates (WSL)
+### 1. Generate certificates (WSL)
 
 ```bash
-cd k8s/scripts/local
-./setup-ca.sh
+cd k8s/scripts
+./setup-ca.sh --env local
 ```
 
-This creates:
-- A local Certificate Authority (CA)
-- TLS certificates for `*.localhost` domains
-- Kubernetes Secret and ConfigMap manifests
-
-#### Step 2: Configure Windows (PowerShell as Administrator)
-
-Navigate to the project directory and run:
+### 2. Trust CA + hosts entries on Windows (PowerShell as Administrator)
 
 ```powershell
 cd k8s\scripts\windows
 .\setup-all.ps1
 ```
 
-Or run the scripts individually:
+Or run separately:
 
 ```powershell
-# Install CA certificate to Windows trust store
 .\install-ca.ps1
-
-# Add local domains to hosts file
 .\setup-hosts.ps1
 ```
 
-**What this does:**
-- Installs the CA certificate so Windows browsers (Chrome, Edge) trust it
-- Adds entries to `C:\Windows\System32\drivers\etc\hosts`
-
-#### Step 3: Set Up Kubernetes Cluster (WSL)
+### 3. Install ingress and cluster resources (WSL)
 
 ```bash
-cd k8s/scripts/local
-./setup-cluster.sh
+cd k8s/scripts
+./setup-cluster.sh --env local
 ```
 
-This:
-- Installs nginx-ingress controller via Helm
-- Creates the `devhub` namespace
-- Applies TLS secrets and CA certificates
-
-#### Step 4: Deploy DevOps Platform (WSL)
+### 4. Deploy platform services (WSL)
 
 ```bash
-cd k8s/scripts/local
-./deploy.sh
+cd k8s/scripts
+./deploy.sh --env local
 ```
 
-#### Step 5: Configure Services (WSL)
+### 5. Configure Keycloak and Vault (WSL)
 
 ```bash
-# Initialize and configure Vault
-./setup-vault.sh
-
-# Configure Keycloak realm and OIDC clients
-./setup-keycloak.sh
-
-# Bootstrap ArgoCD app-of-apps
-./deploy.sh local bootstrap
+cd k8s/scripts
+./setup-keycloak.sh --env local all
+./setup-vault.sh --env local all
+./deploy.sh --env local bootstrap
 ```
 
-#### Step 6: Access Your Services
+## Access URLs
 
-Open your browser and navigate to:
 - https://keycloak.localhost
 - https://vault.localhost
 - https://gitlab.localhost
 - https://argocd.localhost
 - https://grafana.localhost
 
-You should see a valid (green padlock) HTTPS connection!
+## Credentials
 
-## Making Services Trust the CA
+```bash
+# Keycloak admin
+kubectl get secret keycloak-admin-secret -n keycloak -o jsonpath='{.data.KEYCLOAK_ADMIN_PASSWORD}' | base64 -d
 
-When your containerized services need to make HTTPS calls to other local services, they need to trust the local CA. The setup creates a ConfigMap (`local-ca-certificates`) containing the CA certificate.
+# Grafana admin
+kubectl get secret grafana-admin-secret -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
 
-### Node.js Applications
+# ArgoCD admin
+kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath='{.data.password}' | base64 -d
 
-```yaml
-env:
-  - name: NODE_EXTRA_CA_CERTS
-    value: /etc/ssl/certs/local-ca.crt
-volumeMounts:
-  - name: ca-certificates
-    mountPath: /etc/ssl/certs/local-ca.crt
-    subPath: ca.crt
-volumes:
-  - name: ca-certificates
-    configMap:
-      name: local-ca-certificates
+# GitLab root
+kubectl get secret gitlab-gitlab-initial-root-password -n gitlab -o jsonpath='{.data.password}' | base64 -d
 ```
 
-### .NET Applications
-
-```yaml
-env:
-  - name: SSL_CERT_FILE
-    value: /etc/ssl/certs/local-ca.crt
-volumeMounts:
-  - name: ca-certificates
-    mountPath: /etc/ssl/certs/local-ca.crt
-    subPath: ca.crt
-volumes:
-  - name: ca-certificates
-    configMap:
-      name: local-ca-certificates
-```
-
-### Python Applications
-
-```yaml
-env:
-  - name: REQUESTS_CA_BUNDLE
-    value: /etc/ssl/certs/local-ca.crt
-  - name: SSL_CERT_FILE
-    value: /etc/ssl/certs/local-ca.crt
-volumeMounts:
-  - name: ca-certificates
-    mountPath: /etc/ssl/certs/local-ca.crt
-    subPath: ca.crt
-volumes:
-  - name: ca-certificates
-    configMap:
-      name: local-ca-certificates
-```
+Keycloak-generated OIDC secrets are written to `k8s/scripts/local/oidc-secrets.env`.
 
 ## Troubleshooting
 
-### Run the diagnostic tool (Windows)
+### Certificates not trusted
 
-```powershell
-cd k8s\scripts\windows
-.\troubleshoot.ps1
-```
+1. Re-run `install-ca.ps1` as Administrator.
+2. Restart browser.
+3. Verify in `certmgr.msc` under Trusted Root Certification Authorities.
 
-### Common Issues
+### Domain not resolving
 
-#### Certificate not trusted in browser
-1. Re-run `install-ca.ps1` as Administrator
-2. Restart your browser completely
-3. Check if the CA is in Windows Certificate Manager:
-   - Run `certmgr.msc`
-   - Look under "Trusted Root Certification Authorities" → "Certificates"
-   - Find "Local Development CA"
+1. Check `C:\Windows\System32\drivers\etc\hosts`.
+2. Run `ipconfig /flushdns`.
 
-#### Cannot access local domains
-1. Check hosts file: `type C:\Windows\System32\drivers\etc\hosts`
-2. Flush DNS: `ipconfig /flushdns`
-3. Verify with: `ping app.localhost`
+### Ingress issues
 
-#### Ingress not working
 ```bash
-# Check ingress controller pods
 kubectl get pods -n ingress-nginx
-
-# Check ingress service
 kubectl get svc -n ingress-nginx
-
-# Check ingress rules
-kubectl get ingress -n devhub
-kubectl describe ingress -n devhub
+kubectl get ingress -A
 ```
 
-#### Services can't reach each other with HTTPS
-1. Verify CA ConfigMap exists: `kubectl get configmap local-ca-certificates -n devhub`
-2. Check pod has the volume mounted correctly
-3. Check the environment variable is set
+### Service communication over HTTPS fails
 
-## Adding New Domains
+Ensure `local-ca-certificates` ConfigMap is mounted and app CA env var is set (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, etc.).
 
-1. Edit [setup-ca.sh](../scripts/local/setup-ca.sh) and add domains to the `DOMAINS` array
-2. Re-run `./setup-ca.sh` (this regenerates certificates)
-3. Update `hosts` file on Windows: `.\setup-hosts.ps1`
-4. Update [overlays/local/apps/ingress.yaml](../overlays/local/apps/ingress.yaml) for apps
-5. Or update [overlays/local/devops/ingress.yaml](../overlays/local/devops/ingress.yaml) for devops
+## Add More Local Domains
 
-## Firefox Support
+1. Edit [setup-ca.sh](../scripts/setup-ca.sh) and add entries to `DOMAINS`.
+2. Re-run `./setup-ca.sh --env local`.
+3. Re-run `k8s/scripts/windows/setup-hosts.ps1`.
+4. Update ingress manifests in [overlays/local/devops/ingress.yaml](../overlays/local/devops/ingress.yaml) or app ingress manifests.
 
-Firefox uses its own certificate store. To trust the local CA:
+## Firefox
 
-1. Open Firefox Settings
-2. Search for "certificates"
-3. Click "View Certificates"
-4. Go to "Authorities" tab
-5. Click "Import" and select the CA certificate from:
-   - WSL path: `\\wsl$\Ubuntu\home\<user>\code\devhub\k8s\certs\ca\ca.crt`
-6. Check "Trust this CA to identify websites"
-7. Click OK
+Firefox uses its own certificate store. Import `k8s/certs/ca/ca.crt` into Firefox Authorities and trust it for websites.

--- a/k8s/docs/LOCAL_SETUP.md
+++ b/k8s/docs/LOCAL_SETUP.md
@@ -7,7 +7,7 @@ This guide sets up trusted HTTPS for local Kubernetes development on Windows wit
 - Windows 10/11
 - WSL2 (Ubuntu or similar)
 - Rancher Desktop (or another local Kubernetes distribution)
-- `kubectl`, `helm`, `openssl`, `jq`, `envsubst` in WSL
+- `kubectl`, `helm`, `openssl`, `jq`, `envsubst`, `curl` in WSL
 
 ## Quick Start (Automated)
 

--- a/k8s/docs/SSO_TESTING_GUIDE.md
+++ b/k8s/docs/SSO_TESTING_GUIDE.md
@@ -30,7 +30,7 @@
 4. You'll be redirected to Keycloak login page
 5. Enter credentials:
    - Username: `platform-admin`
-   - Password: `Platform123!`
+   - Password: value from `PLATFORM_ADMIN_PASSWORD`
 6. Click "Sign In"
 7. You should be redirected back to Grafana
 8. **Expected Result**: You are logged in as admin with full access
@@ -52,7 +52,7 @@
 5. You'll be redirected to Keycloak login page
 6. Enter credentials:
    - Username: `platform-admin`
-   - Password: `Platform123!`
+   - Password: value from `PLATFORM_ADMIN_PASSWORD`
 7. Click "Sign In"
 8. You should be redirected back to GitLab
 9. **Expected Result**: You are logged in and a new GitLab account is auto-created
@@ -76,7 +76,7 @@
 5. You'll be redirected to Keycloak login page
 6. Enter credentials:
    - Username: `platform-admin`
-   - Password: `Platform123!`
+   - Password: value from `PLATFORM_ADMIN_PASSWORD`
 7. Click "Sign In"
 8. You should be redirected back to ArgoCD
 9. **Expected Result**: You are logged in with admin access


### PR DESCRIPTION
This pull request updates documentation to support multiple cloud providers (Azure, GCP, AWS) in addition to UpCloud, and improves clarity and usability for local development setup. It refactors environment descriptions, deployment instructions, and setup guides to be more generic and comprehensive. The changes also streamline local setup steps, provide clearer troubleshooting and credential instructions, and update SSO testing documentation for consistency.

**Cloud provider support and environment structure:**
* Expanded environment and infrastructure documentation to include Azure, GCP, and AWS, with updated tables and directory structures in `README.md` and `k8s/README.md`. This includes new overlays and modules for each provider and unified descriptions for managed services. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R46) [[3]](diffhunk://#diff-1d8ece659445546a89a71faddc37a9b3fca6fc8e8870b3bb40cadb707e54e946L3-R3) [[4]](diffhunk://#diff-1d8ece659445546a89a71faddc37a9b3fca6fc8e8870b3bb40cadb707e54e946R38-R41) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R95)

**Deployment and setup instructions:**
* Refactored deployment scripts and usage instructions to support all cloud environments and simplified component descriptions. Updated `setup-all.sh`, `setup-keycloak.sh`, and related script usage to accept an `--env` parameter for environment selection. [[1]](diffhunk://#diff-1d8ece659445546a89a71faddc37a9b3fca6fc8e8870b3bb40cadb707e54e946L98-R111) [[2]](diffhunk://#diff-eb89c5001b7cddd22314926183231fe5646045385d5df7bc89aa879fbbb97cc4L99-R104) [[3]](diffhunk://#diff-eb89c5001b7cddd22314926183231fe5646045385d5df7bc89aa879fbbb97cc4L181-R183)

**Local development and troubleshooting guides:**
* Overhauled `LOCAL_SETUP.md` to clarify local development steps, automate the process, and provide explicit credential retrieval commands. Improved troubleshooting sections for certificate, DNS, and ingress issues, and added guidance for service-to-service HTTPS trust and adding new domains.

**SSO testing documentation:**
* Updated SSO testing guide to use the dynamically generated `PLATFORM_ADMIN_PASSWORD` instead of a hardcoded password, ensuring instructions match the current setup. [[1]](diffhunk://#diff-9b1616c1d53dd3513c056623269a2a48fbbadcd3f03d34861c0c80e31a21c565L33-R33) [[2]](diffhunk://#diff-9b1616c1d53dd3513c056623269a2a48fbbadcd3f03d34861c0c80e31a21c565L55-R55) [[3]](diffhunk://#diff-9b1616c1d53dd3513c056623269a2a48fbbadcd3f03d34861c0c80e31a21c565L79-R79)