### PR TITLE
Add External-DNS with per-cloud IAM (Route53/Azure DNS/Cloud DNS/Clou…

### DIFF
--- a/k8s/base/devops/external-dns/values.yaml
+++ b/k8s/base/devops/external-dns/values.yaml
@@ -1,48 +1,23 @@
 # external-dns Helm values
 # Chart: external-dns/external-dns
-# Docs: https://github.com/kubernetes-sigs/external-dns
+# Docs: https://kubernetes-sigs.github.io/external-dns/
 #
-# Domain configuration is provided by overlays:
-#   - overlays/upcloud/devops/external-dns/values.yaml
+# Provider and credentials are set in the cloud-specific overlay:
+#   - overlays/aws/devops/external-dns/values.yaml     (Route53 + IRSA)
+#   - overlays/azure/devops/external-dns/values.yaml   (Azure DNS + Workload Identity)
+#   - overlays/gcp/devops/external-dns/values.yaml     (Cloud DNS + Workload Identity)
+#   - overlays/upcloud/devops/external-dns/values.yaml (Cloudflare)
 
-# UPDATE: Configure for your DNS provider
-# Common providers: cloudflare, aws, azure, google, digitalocean
-
-# Example for Cloudflare:
-provider: cloudflare
-
-# Cloudflare configuration
-cloudflare:
-  # Set via secret or environment variable
-  apiToken: ""
-  proxied: false
-
-# Or use environment variables from a secret
-env:
-  - name: CF_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: external-dns-cloudflare
-        key: api-token
-        optional: true
-
-# Domain filter - overridden by overlays
-domainFilters: []
-
-# Don't create records, just log (for testing)
-# dryRun: true
-
-# Ownership tracking
-txtOwnerId: devops-cluster
+# Ownership tracking — prevents external-dns instances from clobbering each other's records
+txtOwnerId: devhub-cluster
 txtPrefix: externaldns-
 
 # How often to sync
 interval: 1m
 
-# Policy: sync (create/update/delete) or upsert-only (create/update only)
+# Policy: sync (create/update/delete) or upsert-only (create/update, never delete)
 policy: sync
 
-# Log level
 logLevel: info
 
 resources:
@@ -53,6 +28,6 @@ resources:
     cpu: 100m
     memory: 128Mi
 
-# Prometheus metrics
+# Prometheus metrics — scraped by kube-prometheus-stack
 serviceMonitor:
   enabled: true

--- a/k8s/overlays/aws-dev/config.yaml
+++ b/k8s/overlays/aws-dev/config.yaml
@@ -41,3 +41,7 @@ cognitoIdp:
   issuerUrl: PENDING_TOFU_OUTPUT
   hostedUiDomain: PENDING_TOFU_OUTPUT
   clientId: PENDING_TOFU_OUTPUT
+
+# External-DNS — populated by sync-tofu-outputs.sh
+externalDns:
+  irsaRoleArn: PENDING_TOFU_OUTPUT

--- a/k8s/overlays/aws-prod/config.yaml
+++ b/k8s/overlays/aws-prod/config.yaml
@@ -41,3 +41,7 @@ cognitoIdp:
   issuerUrl: PENDING_TOFU_OUTPUT
   hostedUiDomain: PENDING_TOFU_OUTPUT
   clientId: PENDING_TOFU_OUTPUT
+
+# External-DNS — populated by sync-tofu-outputs.sh
+externalDns:
+  irsaRoleArn: PENDING_TOFU_OUTPUT

--- a/k8s/overlays/aws/devops/external-dns/values.yaml
+++ b/k8s/overlays/aws/devops/external-dns/values.yaml
@@ -1,3 +1,15 @@
-# external-dns AWS overlay
+# external-dns AWS overlay — Route53 provider via IRSA
+# The IAM role ARN is provisioned by tofu and written to config.yaml by sync-tofu-outputs.sh.
+
+provider: aws
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: ${EXTERNAL_DNS_IRSA_ROLE_ARN}
+
 domainFilters:
   - ${DOMAIN}
+
+# Route53-specific: use the hosted zone ID filter for faster lookups (optional but recommended)
+# aws:
+#   zoneType: public  # public | private

--- a/k8s/overlays/azure-dev/config.yaml
+++ b/k8s/overlays/azure-dev/config.yaml
@@ -39,3 +39,7 @@ dataServices:
 entraId:
   tenantId: PENDING_TOFU_OUTPUT
   clientId: PENDING_TOFU_OUTPUT
+
+# External-DNS — populated by sync-tofu-outputs.sh
+externalDns:
+  identityClientId: PENDING_TOFU_OUTPUT

--- a/k8s/overlays/azure-prod/config.yaml
+++ b/k8s/overlays/azure-prod/config.yaml
@@ -39,3 +39,7 @@ dataServices:
 entraId:
   tenantId: PENDING_TOFU_OUTPUT
   clientId: PENDING_TOFU_OUTPUT
+
+# External-DNS — populated by sync-tofu-outputs.sh
+externalDns:
+  identityClientId: PENDING_TOFU_OUTPUT

--- a/k8s/overlays/azure/devops/external-dns/values.yaml
+++ b/k8s/overlays/azure/devops/external-dns/values.yaml
@@ -1,5 +1,21 @@
-# external-dns Azure overlay values
-# Domain filter for DNS management
+# external-dns Azure overlay — Azure DNS provider via Workload Identity
+# The managed identity client ID is provisioned by tofu and written to config.yaml by sync-tofu-outputs.sh.
+
+provider: azure
+
+azure:
+  useWorkloadIdentityExtension: true
+  # resourceGroup: the resource group containing the Azure DNS zone.
+  # Defaults to the cluster resource group — override here if your DNS zone is in a separate RG.
+
+# Workload Identity: annotate the service account so AKS binds the federated credential
+serviceAccount:
+  annotations:
+    azure.workload.identity/client-id: ${EXTERNAL_DNS_IDENTITY_CLIENT_ID}
+
+# Workload Identity requires this pod label
+podLabels:
+  azure.workload.identity/use: "true"
 
 domainFilters:
   - ${DOMAIN}

--- a/k8s/overlays/gcp-dev/config.yaml
+++ b/k8s/overlays/gcp-dev/config.yaml
@@ -39,3 +39,7 @@ dataServices:
 # Google Identity Provider — populated by sync-tofu-outputs.sh (template)
 googleIdp:
   clientId: FILL_IN_MANUALLY
+
+# External-DNS — populated by sync-tofu-outputs.sh
+externalDns:
+  gsaEmail: PENDING_TOFU_OUTPUT

--- a/k8s/overlays/gcp-prod/config.yaml
+++ b/k8s/overlays/gcp-prod/config.yaml
@@ -39,3 +39,7 @@ dataServices:
 # Google Identity Provider — populated by sync-tofu-outputs.sh (template)
 googleIdp:
   clientId: FILL_IN_MANUALLY
+
+# External-DNS — populated by sync-tofu-outputs.sh
+externalDns:
+  gsaEmail: PENDING_TOFU_OUTPUT

--- a/k8s/overlays/gcp/devops/external-dns/values.yaml
+++ b/k8s/overlays/gcp/devops/external-dns/values.yaml
@@ -1,3 +1,11 @@
-# external-dns GCP overlay
+# external-dns GCP overlay — Cloud DNS provider via Workload Identity
+# The Google Service Account email is provisioned by tofu and written to config.yaml by sync-tofu-outputs.sh.
+
+provider: google
+
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: ${EXTERNAL_DNS_GSA_EMAIL}
+
 domainFilters:
   - ${DOMAIN}

--- a/k8s/overlays/upcloud/devops/external-dns/values.yaml
+++ b/k8s/overlays/upcloud/devops/external-dns/values.yaml
@@ -1,5 +1,21 @@
-# external-dns UpCloud overlay values
-# Domain filter for DNS management
+# external-dns UpCloud overlay — Cloudflare provider
+# UpCloud does not have a native external-dns provider; use Cloudflare as the DNS authority.
+#
+# Pre-requisite: create the secret before deploying:
+#   kubectl create secret generic external-dns-cloudflare -n external-dns \
+#     --from-literal=api-token=<your-cloudflare-api-token>
+
+provider: cloudflare
+
+cloudflare:
+  proxied: false  # Set true to proxy traffic through Cloudflare (hides origin IP)
+
+env:
+  - name: CF_API_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: external-dns-cloudflare
+        key: api-token
 
 domainFilters:
   - ${DOMAIN}

--- a/k8s/scripts/deploy.sh
+++ b/k8s/scripts/deploy.sh
@@ -318,6 +318,25 @@ install_vault() {
     log_info "Vault installed"
 }
 
+install_external_dns() {
+    if [[ "$ENV" == "local" ]]; then
+        log_info "Skipping external-dns (not needed for local)"
+        return 0
+    fi
+
+    log_step "Installing external-dns..."
+
+    local values_args=$(get_values_args "external-dns")
+
+    helm upgrade --install external-dns external-dns/external-dns \
+        --namespace external-dns \
+        --create-namespace \
+        $values_args \
+        --wait --timeout 5m
+
+    log_info "external-dns installed"
+}
+
 install_external_secrets() {
     log_step "Installing External Secrets..."
 
@@ -574,6 +593,7 @@ deploy_devops() {
     create_devops_namespaces
     [[ "$ENV" == "local" ]] && copy_tls_secrets
     install_cert_manager
+    install_external_dns
     install_data_services
     install_monitoring
     install_keycloak
@@ -592,6 +612,7 @@ delete_devops() {
     kubectl delete -f "${BASE_DIR}/crossplane/provider-config.yaml" 2>/dev/null || true
     helm uninstall crossplane -n crossplane-system 2>/dev/null || true
     helm uninstall argocd -n argocd 2>/dev/null || true
+    helm uninstall external-dns -n external-dns 2>/dev/null || true
     helm uninstall gitlab -n gitlab 2>/dev/null || true
     helm uninstall prometheus -n monitoring 2>/dev/null || true
     helm uninstall loki -n monitoring 2>/dev/null || true
@@ -622,7 +643,7 @@ delete_devops() {
 status_devops() {
     log_step "DevOps Platform Status:"
     echo ""
-    for ns in data-services keycloak vault gitlab argocd monitoring external-secrets cert-manager crossplane-system; do
+    for ns in data-services keycloak vault gitlab argocd monitoring external-secrets cert-manager crossplane-system external-dns; do
         echo "=== ${ns} ==="
         kubectl get pods -n "$ns" 2>/dev/null || echo "  Namespace not found"
         echo ""
@@ -710,6 +731,9 @@ main() {
                 crossplane)
                     add_helm_repos && install_crossplane
                     ;;
+                external-dns)
+                    add_helm_repos && install_external_dns
+                    ;;
                 ingress)
                     apply_devops_ingress
                     ;;
@@ -741,7 +765,7 @@ main() {
             echo "Components:"
             echo "  all        - Deploy entire platform (alias for devops)"
             echo "  devops     - DevOps platform"
-            echo "  data-services, keycloak, vault, monitoring, gitlab, argocd, crossplane - Individual components"
+            echo "  data-services, keycloak, vault, monitoring, gitlab, argocd, crossplane, external-dns - Individual components"
             echo "  bootstrap  - Deploy ArgoCD app-of-apps for GitOps"
             echo ""
             echo "Actions:"

--- a/k8s/scripts/lib/common.sh
+++ b/k8s/scripts/lib/common.sh
@@ -128,6 +128,10 @@ parse_config() {
         export COGNITO_CLIENT_ID="${COGNITO_CLIENT_ID:-$(grep -A3 '^cognitoIdp:' "$config_file" | grep 'clientId:' | sed 's/.*clientId:[[:space:]]*//' | _yaml_val)}"
         # GCP: Google IdP (non-sensitive; secret is in gcp-idp.env)
         export GOOGLE_IDP_CLIENT_ID="${GOOGLE_IDP_CLIENT_ID:-$(grep -A1 '^googleIdp:' "$config_file" | grep 'clientId:' | sed 's/.*clientId:[[:space:]]*//' | _yaml_val)}"
+        # External-DNS identity (cloud-specific)
+        export EXTERNAL_DNS_IRSA_ROLE_ARN="${EXTERNAL_DNS_IRSA_ROLE_ARN:-$(grep -A2 '^externalDns:' "$config_file" | grep 'irsaRoleArn:' | sed 's/.*irsaRoleArn:[[:space:]]*//' | _yaml_val)}"
+        export EXTERNAL_DNS_IDENTITY_CLIENT_ID="${EXTERNAL_DNS_IDENTITY_CLIENT_ID:-$(grep -A2 '^externalDns:' "$config_file" | grep 'identityClientId:' | sed 's/.*identityClientId:[[:space:]]*//' | _yaml_val)}"
+        export EXTERNAL_DNS_GSA_EMAIL="${EXTERNAL_DNS_GSA_EMAIL:-$(grep -A2 '^externalDns:' "$config_file" | grep 'gsaEmail:' | sed 's/.*gsaEmail:[[:space:]]*//' | _yaml_val)}"
     else
         export PG_HOST="${PG_HOST:-}"
         export VALKEY_HOST="${VALKEY_HOST:-}"
@@ -148,6 +152,9 @@ parse_config() {
         export COGNITO_HOSTED_UI_DOMAIN="${COGNITO_HOSTED_UI_DOMAIN:-}"
         export COGNITO_CLIENT_ID="${COGNITO_CLIENT_ID:-}"
         export GOOGLE_IDP_CLIENT_ID="${GOOGLE_IDP_CLIENT_ID:-}"
+        export EXTERNAL_DNS_IRSA_ROLE_ARN="${EXTERNAL_DNS_IRSA_ROLE_ARN:-}"
+        export EXTERNAL_DNS_IDENTITY_CLIENT_ID="${EXTERNAL_DNS_IDENTITY_CLIENT_ID:-}"
+        export EXTERNAL_DNS_GSA_EMAIL="${EXTERNAL_DNS_GSA_EMAIL:-}"
     fi
 }
 
@@ -160,7 +167,7 @@ parse_config() {
 template_values() {
     local input="$1"
     local output="$2"
-    envsubst '${DOMAIN} ${TLS_SECRET_NAME} ${CLUSTER_ISSUER} ${ACME_EMAIL} ${PG_HOST} ${VALKEY_HOST} ${S3_ENDPOINT} ${S3_REGION} ${REDIS_HOST} ${AZURE_STORAGE_ACCOUNT} ${GITLAB_IDENTITY_CLIENT_ID} ${GCS_PROJECT_ID} ${GCS_BUCKET_PREFIX} ${GITLAB_GSA_EMAIL} ${AWS_REGION} ${S3_BUCKET_PREFIX} ${GITLAB_IRSA_ROLE_ARN}' < "$input" > "$output"
+    envsubst '${DOMAIN} ${TLS_SECRET_NAME} ${CLUSTER_ISSUER} ${ACME_EMAIL} ${PG_HOST} ${VALKEY_HOST} ${S3_ENDPOINT} ${S3_REGION} ${REDIS_HOST} ${AZURE_STORAGE_ACCOUNT} ${GITLAB_IDENTITY_CLIENT_ID} ${GCS_PROJECT_ID} ${GCS_BUCKET_PREFIX} ${GITLAB_GSA_EMAIL} ${AWS_REGION} ${S3_BUCKET_PREFIX} ${GITLAB_IRSA_ROLE_ARN} ${EXTERNAL_DNS_IRSA_ROLE_ARN} ${EXTERNAL_DNS_IDENTITY_CLIENT_ID} ${EXTERNAL_DNS_GSA_EMAIL}' < "$input" > "$output"
 }
 
 # Get Helm values args for a component (base + templated overlay).
@@ -206,6 +213,7 @@ add_helm_repos() {
     helm repo add argo https://argoproj.github.io/argo-helm 2>/dev/null || true
     helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx 2>/dev/null || true
     helm repo add crossplane-stable https://charts.crossplane.io/stable 2>/dev/null || true
+    helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/ 2>/dev/null || true
 
     helm repo update
     log_info "Helm repositories updated"

--- a/k8s/scripts/sync-tofu-outputs.sh
+++ b/k8s/scripts/sync-tofu-outputs.sh
@@ -76,13 +76,15 @@ if [[ "$CLOUD" == "gcp" ]]; then
     GCS_PROJECT_ID=$(echo "$OUTPUTS" | jq -r '.project_id.value')
     GCS_BUCKET_PREFIX=$(echo "$OUTPUTS" | jq -r '.gitlab_gcs_bucket_prefix.value')
     GITLAB_GSA_EMAIL=$(echo "$OUTPUTS" | jq -r '.gitlab_gsa_email.value')
+    EXTERNAL_DNS_GSA_EMAIL=$(echo "$OUTPUTS" | jq -r '.external_dns_gsa_email.value')
     GCP_REGION=$(echo "$OUTPUTS" | jq -r '.region.value')
 
     log_info "PostgreSQL:        ${PG_HOST}:${PG_PORT}"
     log_info "Redis:             ${REDIS_HOST}:${REDIS_PORT}"
     log_info "GCS Project:       ${GCS_PROJECT_ID}"
     log_info "GCS Bucket Prefix: ${GCS_BUCKET_PREFIX}"
-    log_info "GitLab GSA:        ${GITLAB_GSA_EMAIL}"
+    log_info "GitLab GSA:           ${GITLAB_GSA_EMAIL}"
+    log_info "External-DNS GSA:     ${EXTERNAL_DNS_GSA_EMAIL}"
     log_info "Cluster:           ${CLUSTER_NAME}"
 
 elif [[ "$CLOUD" == "aws" ]]; then
@@ -91,6 +93,7 @@ elif [[ "$CLOUD" == "aws" ]]; then
     AWS_REGION=$(echo "$OUTPUTS" | jq -r '.aws_region.value')
     S3_BUCKET_PREFIX=$(echo "$OUTPUTS" | jq -r '.gitlab_s3_bucket_prefix.value')
     GITLAB_IRSA_ROLE_ARN=$(echo "$OUTPUTS" | jq -r '.gitlab_irsa_role_arn.value')
+    EXTERNAL_DNS_IRSA_ROLE_ARN=$(echo "$OUTPUTS" | jq -r '.external_dns_irsa_role_arn.value')
     COGNITO_ISSUER_URL=$(echo "$OUTPUTS" | jq -r '.cognito_issuer_url.value')
     COGNITO_HOSTED_UI_DOMAIN=$(echo "$OUTPUTS" | jq -r '.cognito_hosted_ui_domain.value')
     COGNITO_CLIENT_ID=$(echo "$OUTPUTS" | jq -r '.cognito_client_id.value')
@@ -100,7 +103,8 @@ elif [[ "$CLOUD" == "aws" ]]; then
     log_info "Redis:               ${REDIS_HOST}:${REDIS_PORT}"
     log_info "S3 Region:           ${AWS_REGION}"
     log_info "S3 Bucket Prefix:    ${S3_BUCKET_PREFIX}"
-    log_info "GitLab IRSA ARN:     ${GITLAB_IRSA_ROLE_ARN}"
+    log_info "GitLab IRSA ARN:        ${GITLAB_IRSA_ROLE_ARN}"
+    log_info "External-DNS IRSA ARN:  ${EXTERNAL_DNS_IRSA_ROLE_ARN}"
     log_info "Cognito Issuer:      ${COGNITO_ISSUER_URL}"
     log_info "Cognito Domain:      ${COGNITO_HOSTED_UI_DOMAIN}"
     log_info "Cognito Client:      ${COGNITO_CLIENT_ID}"
@@ -121,6 +125,7 @@ else
     REDIS_PORT=$(echo "$OUTPUTS" | jq -r '.redis_port.value')
     STORAGE_ACCOUNT=$(echo "$OUTPUTS" | jq -r '.storage_account_name.value')
     GITLAB_IDENTITY_CLIENT_ID=$(echo "$OUTPUTS" | jq -r '.gitlab_identity_client_id.value')
+    EXTERNAL_DNS_IDENTITY_CLIENT_ID=$(echo "$OUTPUTS" | jq -r '.external_dns_identity_client_id.value')
     RESOURCE_GROUP=$(echo "$OUTPUTS" | jq -r '.resource_group_name.value')
     ENTRA_TENANT_ID=$(echo "$OUTPUTS" | jq -r '.entra_tenant_id.value')
     ENTRA_KEYCLOAK_CLIENT_ID=$(echo "$OUTPUTS" | jq -r '.entra_keycloak_client_id.value')
@@ -129,7 +134,8 @@ else
     log_info "PostgreSQL:       ${PG_HOST}:${PG_PORT}"
     log_info "Redis:            ${REDIS_HOST}:${REDIS_PORT}"
     log_info "Storage Account:  ${STORAGE_ACCOUNT}"
-    log_info "GitLab Identity:  ${GITLAB_IDENTITY_CLIENT_ID}"
+    log_info "GitLab Identity:      ${GITLAB_IDENTITY_CLIENT_ID}"
+    log_info "External-DNS Identity: ${EXTERNAL_DNS_IDENTITY_CLIENT_ID}"
     log_info "Entra Tenant:     ${ENTRA_TENANT_ID}"
     log_info "Entra Client:     ${ENTRA_KEYCLOAK_CLIENT_ID}"
     log_info "Cluster:          ${CLUSTER_NAME}"
@@ -146,6 +152,10 @@ if [[ "$CLOUD" == "gcp" ]]; then
         /gcs:/,/projectId:/ { s|projectId: .*|projectId: ${GCS_PROJECT_ID}| }
         /gcs:/,/bucketPrefix:/ { s|bucketPrefix: .*|bucketPrefix: ${GCS_BUCKET_PREFIX}| }
         /gcs:/,/gitlabGsaEmail:/ { s|gitlabGsaEmail: .*|gitlabGsaEmail: ${GITLAB_GSA_EMAIL}| }
+    }" "$CONFIG_FILE"
+
+    sed -i "/^externalDns:/,\$ {
+        s|gsaEmail: .*|gsaEmail: ${EXTERNAL_DNS_GSA_EMAIL}|
     }" "$CONFIG_FILE"
 
     # Write Google IdP client secret template (fill in manually after creating OAuth client)
@@ -184,6 +194,10 @@ elif [[ "$CLOUD" == "aws" ]]; then
         /s3:/,/region:/ { s|region: .*|region: ${AWS_REGION}| }
         /s3:/,/bucketPrefix:/ { s|bucketPrefix: .*|bucketPrefix: ${S3_BUCKET_PREFIX}| }
         /s3:/,/gitlabIrsaRoleArn:/ { s|gitlabIrsaRoleArn: .*|gitlabIrsaRoleArn: ${GITLAB_IRSA_ROLE_ARN}| }
+    }" "$CONFIG_FILE"
+
+    sed -i "/^externalDns:/,\$ {
+        s|irsaRoleArn: .*|irsaRoleArn: ${EXTERNAL_DNS_IRSA_ROLE_ARN}|
     }" "$CONFIG_FILE"
 
     # Write non-sensitive Cognito values into config.yaml
@@ -225,6 +239,10 @@ else
     sed -i "/^entraId:/,\$ {
         s|tenantId: .*|tenantId: ${ENTRA_TENANT_ID}|
         s|clientId: .*|clientId: ${ENTRA_KEYCLOAK_CLIENT_ID}|
+    }" "$CONFIG_FILE"
+
+    sed -i "/^externalDns:/,\$ {
+        s|identityClientId: .*|identityClientId: ${EXTERNAL_DNS_IDENTITY_CLIENT_ID}|
     }" "$CONFIG_FILE"
 
     # Write the client secret to a local env file (gitignored, read by setup-keycloak.sh)

--- a/tofu/aws/dev/main.tf
+++ b/tofu/aws/dev/main.tf
@@ -24,6 +24,9 @@ module "cluster" {
   redis_num_cache_clusters = 1
   redis_automatic_failover = false
 
+  # DNS — must match an existing Route53 hosted zone
+  domain = "dev.example.com" # TODO: set to your actual domain
+
   # Cognito — domain prefix must be globally unique
   cognito_domain_prefix = "devhub-dev-devhub" # TODO: customize to avoid conflicts
 

--- a/tofu/aws/modules/cluster/main.tf
+++ b/tofu/aws/modules/cluster/main.tf
@@ -640,3 +640,64 @@ resource "aws_iam_role_policy" "gitlab_s3" {
   role        = aws_iam_role.gitlab_irsa.id
   policy      = data.aws_iam_policy_document.gitlab_s3.json
 }
+
+# ─── External-DNS IRSA ───────────────────────────────────────────────
+# Allows external-dns to manage Route53 records for the cluster's domain.
+# The K8s service account "external-dns/external-dns" assumes this role via IRSA.
+
+data "aws_route53_zone" "main" {
+  name         = var.domain
+  private_zone = false
+}
+
+data "aws_iam_policy_document" "external_dns_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.eks.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:external-dns:external-dns"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "external_dns_irsa" {
+  name_prefix        = "${var.prefix}-external-dns-irsa-"
+  assume_role_policy = data.aws_iam_policy_document.external_dns_assume_role.json
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "external_dns_route53" {
+  statement {
+    effect    = "Allow"
+    actions   = ["route53:ChangeResourceRecordSets"]
+    resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.main.zone_id}"]
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["route53:ListHostedZones", "route53:ListResourceRecordSets", "route53:ListTagsForResource"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "external_dns_route53" {
+  name_prefix = "${var.prefix}-external-dns-route53-"
+  role        = aws_iam_role.external_dns_irsa.id
+  policy      = data.aws_iam_policy_document.external_dns_route53.json
+}

--- a/tofu/aws/modules/cluster/outputs.tf
+++ b/tofu/aws/modules/cluster/outputs.tf
@@ -76,6 +76,11 @@ output "gitlab_irsa_role_arn" {
   value       = aws_iam_role.gitlab_irsa.arn
 }
 
+output "external_dns_irsa_role_arn" {
+  description = "IAM Role ARN for external-dns IRSA — written to config.yaml by sync-tofu-outputs.sh"
+  value       = aws_iam_role.external_dns_irsa.arn
+}
+
 # ─── Cognito ─────────────────────────────────────────────────────────
 
 output "cognito_user_pool_id" {

--- a/tofu/aws/modules/cluster/variables.tf
+++ b/tofu/aws/modules/cluster/variables.tf
@@ -96,6 +96,13 @@ variable "redis_automatic_failover" {
   default     = false
 }
 
+# ─── DNS ─────────────────────────────────────────────────────────────
+
+variable "domain" {
+  description = "Public domain name for the cluster (e.g., dev.example.com) — must have an existing Route53 hosted zone"
+  type        = string
+}
+
 # ─── Cognito (IdP for Keycloak) ───────────────────────────────────────
 
 variable "cognito_domain_prefix" {

--- a/tofu/aws/prod/main.tf
+++ b/tofu/aws/prod/main.tf
@@ -24,6 +24,9 @@ module "cluster" {
   redis_num_cache_clusters = 2
   redis_automatic_failover = true
 
+  # DNS — must match an existing Route53 hosted zone
+  domain = "example.com" # TODO: set to your actual domain
+
   # Cognito — domain prefix must be globally unique
   cognito_domain_prefix = "devhub-prod-devhub" # TODO: customize to avoid conflicts
 

--- a/tofu/azure/dev/main.tf
+++ b/tofu/azure/dev/main.tf
@@ -24,6 +24,10 @@ module "cluster" {
   # Blob storage — locally-redundant for dev
   storage_replication = "LRS"
 
+  # DNS — must match an existing Azure DNS zone
+  domain = "dev.example.com" # TODO: set to your actual domain
+  # dns_zone_resource_group = "my-dns-rg"  # uncomment if DNS zone is in a separate RG
+
   enable_delete_lock = false
 
   tags = {

--- a/tofu/azure/modules/cluster/main.tf
+++ b/tofu/azure/modules/cluster/main.tf
@@ -345,3 +345,34 @@ resource "azurerm_federated_identity_credential" "gitlab" {
   issuer              = azurerm_kubernetes_cluster.main.oidc_issuer_url
   subject             = "system:serviceaccount:gitlab:gitlab"
 }
+
+# ─── External-DNS Workload Identity ──────────────────────────────────
+# Allows external-dns to manage Azure DNS records for the cluster's domain.
+# The K8s service account "external-dns/external-dns" uses the federated credential.
+
+data "azurerm_dns_zone" "main" {
+  name                = var.domain
+  resource_group_name = var.dns_zone_resource_group != "" ? var.dns_zone_resource_group : azurerm_resource_group.main.name
+}
+
+resource "azurerm_user_assigned_identity" "external_dns" {
+  name                = "${var.prefix}-external-dns-identity"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  tags                = var.tags
+}
+
+resource "azurerm_role_assignment" "external_dns_dns_contributor" {
+  scope                = data.azurerm_dns_zone.main.id
+  role_definition_name = "DNS Zone Contributor"
+  principal_id         = azurerm_user_assigned_identity.external_dns.principal_id
+}
+
+resource "azurerm_federated_identity_credential" "external_dns" {
+  name                = "${var.prefix}-external-dns-fedcred"
+  resource_group_name = azurerm_resource_group.main.name
+  parent_id           = azurerm_user_assigned_identity.external_dns.id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.main.oidc_issuer_url
+  subject             = "system:serviceaccount:external-dns:external-dns"
+}

--- a/tofu/azure/modules/cluster/outputs.tf
+++ b/tofu/azure/modules/cluster/outputs.tf
@@ -110,3 +110,8 @@ output "gitlab_identity_client_id" {
   description = "Client ID of the GitLab managed identity — annotate the K8s service account with this value"
   value       = azurerm_user_assigned_identity.gitlab.client_id
 }
+
+output "external_dns_identity_client_id" {
+  description = "Client ID of the external-dns managed identity — written to config.yaml by sync-tofu-outputs.sh"
+  value       = azurerm_user_assigned_identity.external_dns.client_id
+}

--- a/tofu/azure/modules/cluster/variables.tf
+++ b/tofu/azure/modules/cluster/variables.tf
@@ -123,6 +123,19 @@ variable "storage_replication" {
   default     = "LRS"
 }
 
+# ─── DNS ─────────────────────────────────────────────────────────────
+
+variable "domain" {
+  description = "Public domain name for the cluster (e.g., dev.example.com) — must have an existing Azure DNS zone"
+  type        = string
+}
+
+variable "dns_zone_resource_group" {
+  description = "Resource group containing the Azure DNS zone (defaults to the cluster resource group)"
+  type        = string
+  default     = ""
+}
+
 # ─── Entra ID (Azure AD) ──────────────────────────────────────────────
 
 variable "entra_require_assignment" {

--- a/tofu/azure/prod/main.tf
+++ b/tofu/azure/prod/main.tf
@@ -25,6 +25,10 @@ module "cluster" {
   # Blob storage — geo-redundant for production
   storage_replication = "GRS"
 
+  # DNS — must match an existing Azure DNS zone
+  domain = "example.com" # TODO: set to your actual domain
+  # dns_zone_resource_group = "my-dns-rg"  # uncomment if DNS zone is in a separate RG
+
   enable_delete_lock = true
 
   # api_server_authorized_ip_ranges = ["0.0.0.0/0"] # TODO: restrict to known CIDRs

--- a/tofu/gcp/modules/cluster/main.tf
+++ b/tofu/gcp/modules/cluster/main.tf
@@ -414,3 +414,28 @@ resource "google_service_account_iam_member" "gitlab_workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[gitlab/gitlab]"
 }
+
+# ─── External-DNS Workload Identity ──────────────────────────────────
+# Allows external-dns to manage Cloud DNS records for the cluster's domain.
+# The K8s service account "external-dns/external-dns" exchanges its OIDC token
+# for a Google token via Workload Identity.
+
+resource "google_service_account" "external_dns" {
+  project      = var.project_id
+  account_id   = "${var.prefix}-external-dns"
+  display_name = "External-DNS Service Account (Workload Identity)"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_project_iam_member" "external_dns_dns_admin" {
+  project = var.project_id
+  role    = "roles/dns.admin"
+  member  = "serviceAccount:${google_service_account.external_dns.email}"
+}
+
+resource "google_service_account_iam_member" "external_dns_workload_identity" {
+  service_account_id = google_service_account.external_dns.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[external-dns/external-dns]"
+}

--- a/tofu/gcp/modules/cluster/outputs.tf
+++ b/tofu/gcp/modules/cluster/outputs.tf
@@ -81,3 +81,8 @@ output "gitlab_gsa_email" {
   description = "GitLab Google Service Account email — annotate the K8s service account with this value"
   value       = google_service_account.gitlab.email
 }
+
+output "external_dns_gsa_email" {
+  description = "External-DNS Google Service Account email — written to config.yaml by sync-tofu-outputs.sh"
+  value       = google_service_account.external_dns.email
+}


### PR DESCRIPTION
…dflare)

- Helm: provider-agnostic base values; cloud overlays set provider + identity annotations (IRSA, Workload Identity, GCP WI, Cloudflare API token)
- Scripts: install_external_dns() in deploy.sh, external-dns helm repo in common.sh, new env vars templated and parsed; sync-tofu-outputs.sh writes identity outputs to config.yaml for all clouds
- Tofu (AWS): external-dns IRSA role + Route53 policy; domain variable
- Tofu (Azure): managed identity + DNS Zone Contributor + federated credential; domain + dns_zone_resource_group variables
- Tofu (GCP): service account + roles/dns.admin + Workload Identity binding
- All cloud dev/prod config.yaml: externalDns section with PENDING_TOFU_OUTPUT